### PR TITLE
Improve DeviceOrientationControls: iOS permission handling, heading smoothing, API additions

### DIFF
--- a/lib/three/device-orientation-controls.js
+++ b/lib/three/device-orientation-controls.js
@@ -29,14 +29,12 @@ const _euler = new Euler();
 const _q0 = new Quaternion();
 const _q1 = new Quaternion(-Math.sqrt(0.5), 0, 0, Math.sqrt(0.5)); // - PI/2 around the x-axis
 
-const _changeEvent = { type: "change" };
-
 class DeviceOrientationControls extends EventDispatcher {
- /**
+/**
   * Create an instance of DeviceOrientationControls.
   * @param {Object} object - the object to attach the controls to
   * (usually your Three.js camera)
-  * @param {Object} options - options for DeviceOrientationControls: currently accepts smoothingFactor
+  * @param {Object} options - options for DeviceOrientationControls: currently accepts smoothingFactor, enablePermissionDialog
   */
   constructor(object, options = { }) {
     super();
@@ -49,9 +47,6 @@ class DeviceOrientationControls extends EventDispatcher {
 
     const scope = this;
 
-    const EPS = 0.000001;
-    const lastQuaternion = new Quaternion();
-
     this.object = object;
     this.object.rotation.reorder("YXZ");
 
@@ -61,7 +56,11 @@ class DeviceOrientationControls extends EventDispatcher {
     this.screenOrientation = 0;
 
     this.alphaOffset = 0; // radians
+    this.orientationOffset = 0; // iOS orientation offset
     this.initialOffset = null; // used in fix provided in issue #466 on main AR.js repo, iOS related
+
+    this.lastCompassY = undefined;
+    this.lastOrientation = null;
 
     this.TWO_PI = 2 * Math.PI;
     this.HALF_PI = 0.5 * Math.PI;
@@ -69,8 +68,10 @@ class DeviceOrientationControls extends EventDispatcher {
       "ondeviceorientationabsolute" in window
         ? "deviceorientationabsolute"
         : "deviceorientation";
+    console.log("Device Orientation Event Name:", this.orientationChangeEventName);
 
     this.smoothingFactor = options.smoothingFactor || 1;
+    this.enablePermissionDialog = options.enablePermissionDialog ?? true;
 
     const onDeviceOrientationChangeEvent = function ({
       alpha,
@@ -92,12 +93,21 @@ class DeviceOrientationControls extends EventDispatcher {
         }),
       );
     };
-
+    
     const onScreenOrientationChangeEvent = function () {
       scope.screenOrientation = window.orientation || 0;
+      if (isIOS) {
+        if(scope.screenOrientation === 90) {
+            scope.orientationOffset = -scope.HALF_PI;
+        }
+        else if (scope.screenOrientation === -90) {
+            scope.orientationOffset = scope.HALF_PI;
+        }
+        else {
+            scope.orientationOffset = 0;
+        }
+      }
     };
-
-    // The angles alpha, beta and gamma form a set of intrinsic Tait-Bryan angles of type Z-X'-Y''
 
     const setObjectQuaternion = function (
       quaternion,
@@ -160,8 +170,8 @@ class DeviceOrientationControls extends EventDispatcher {
 
       scope.enabled = true;
     };
-
-    this.disconnect = function () {
+    
+    this.disconnect = function() {
       window.removeEventListener(
         "orientationchange",
         onScreenOrientationChangeEvent,
@@ -170,18 +180,17 @@ class DeviceOrientationControls extends EventDispatcher {
         scope.orientationChangeEventName,
         onDeviceOrientationChangeEvent,
       );
-
+      
       scope.enabled = false;
       scope.initialOffset = false;
       scope.deviceOrientation = null;
     };
+    
+    this.update = function({ theta: s = 0 } = { theta: 0 }) {
+    if (scope.enabled === false) return;
+    const device = scope.deviceOrientation;
 
-    this.update = function ({ theta = 0 } = { theta: 0 }) {
-      if (scope.enabled === false) return;
-
-      const device = scope.deviceOrientation;
-
-      if (device) {
+    if (device) {
         let alpha = device.alpha
           ? MathUtils.degToRad(device.alpha) + scope.alphaOffset
           : 0; // Z
@@ -193,134 +202,177 @@ class DeviceOrientationControls extends EventDispatcher {
         const orient = scope.screenOrientation
           ? MathUtils.degToRad(scope.screenOrientation)
           : 0; // O
+      
+      if (scope.smoothingFactor < 1) {
+        if (scope.lastOrientation) {
+          const k = scope.smoothingFactor;
+          alpha = scope._getSmoothedAngle(
+            alpha,
+            scope.lastOrientation.alpha,
+            k,
+          );
+          beta = scope._getSmoothedAngle(
+            beta + Math.PI,
+            scope.lastOrientation.beta,
+            k,
+          );
+          gamma = scope._getSmoothedAngle(
+            gamma + scope.HALF_PI,
+            scope.lastOrientation.gamma,
+            k,
+            Math.PI,
+          );
+        } else {
+          beta += Math.PI;
+          gamma += scope.HALF_PI;
+        }
 
-        if (isIOS) {
-          const currentQuaternion = new Quaternion();
-          setObjectQuaternion(currentQuaternion, alpha, beta, gamma, orient);
-          // Extract the Euler angles from the quaternion and add the heading angle to the Y-axis rotation of the Euler angles
-          // (If we replace only the alpha value of the quaternion without using Euler angles, the camera will rotate unexpectedly. This is because a quaternion does not represent rotation values individually but rather through a combination of rotation axes and weights.)
-          const currentEuler = new Euler().setFromQuaternion(
+        scope.lastOrientation = {
+          alpha,
+          beta,
+          gamma,
+        };
+      }
+      
+      if (isIOS) {
+        const currentQuaternion = new Quaternion();
+        setObjectQuaternion(
+          currentQuaternion,
+          alpha,
+          scope.smoothingFactor < 1 ? beta - Math.PI : beta,
+          scope.smoothingFactor < 1 ? gamma - Math.PI / 2 : gamma,
+          orient
+        );
+      
+        const currentEuler = new Euler().setFromQuaternion(
             currentQuaternion,
             "YXZ",
           );
-          console.log(currentEuler.x, currentEuler.y, currentEuler.z);
-          // Replace the current alpha value of the Euler angles and reset the quaternion
-          currentEuler.y = MathUtils.degToRad(
-            360 - device.webkitCompassHeading,
-          );
-          currentQuaternion.setFromEuler(currentEuler);
-          scope.object.quaternion.copy(currentQuaternion);
-        } else {
-          if (this.smoothingFactor < 1) {
-            if (this.lastOrientation) {
-              const k = this.smoothingFactor;
-              alpha = this._getSmoothedAngle(
-                alpha,
-                this.lastOrientation.alpha,
-                k,
-              );
-              beta = this._getSmoothedAngle(
-                beta + Math.PI,
-                this.lastOrientation.beta,
-                k,
-              );
-              gamma = this._getSmoothedAngle(
-                gamma + this.HALF_PI,
-                this.lastOrientation.gamma,
-                k,
-                Math.PI,
-              );
-            } else {
-              beta += Math.PI;
-              gamma += this.HALF_PI;
-            }
+        
+        let compassY = MathUtils.degToRad(360 - device.webkitCompassHeading);
 
-            this.lastOrientation = {
-              alpha,
-              beta,
-              gamma,
-            };
-          }
-          setObjectQuaternion(
-            scope.object.quaternion,
-            alpha + theta,
-            this.smoothingFactor < 1 ? beta - Math.PI : beta,
-            this.smoothingFactor < 1 ? gamma - this.HALF_PI : gamma,
-            orient,
-          );
+        if (scope.smoothingFactor < 1 && scope.lastCompassY !== void 0) {
+          compassY = scope._getSmoothedAngle(compassY, scope.lastCompassY, scope.smoothingFactor);
         }
 
-        // NB - NOT present in IOS fixed version issue #466
-        // Is it needed?
-        if (8 * (1 - lastQuaternion.dot(scope.object.quaternion)) > EPS) {
-          lastQuaternion.copy(scope.object.quaternion);
-          scope.dispatchEvent(_changeEvent);
-        }
-      }
-    };
+        scope.lastCompassY = compassY;
+        
+        currentEuler.y = compassY + (scope.orientationOffset || 0);
 
-    // NW Added
-    this._orderAngle = function (a, b, range = this.TWO_PI) {
-      if (
-        (b > a && Math.abs(b - a) < range / 2) ||
-        (a > b && Math.abs(b - a) > range / 2)
-      ) {
-        return { left: a, right: b };
+        currentQuaternion.setFromEuler(currentEuler);
+
+        scope.object.quaternion.copy(currentQuaternion);
+
       } else {
-        return { left: b, right: a };
+        setObjectQuaternion(
+          scope.object.quaternion,
+          isIOS ? alpha + scope.alphaOffset : alpha,
+          scope.smoothingFactor < 1 ? beta - Math.PI : beta,
+          scope.smoothingFactor < 1 ? gamma - Math.PI / 2 : gamma,
+          orient
+        );
       }
-    };
-
-    // NW Added
-    this._getSmoothedAngle = function (a, b, k, range = this.TWO_PI) {
-      const angles = this._orderAngle(a, b, range);
-      const angleshift = angles.left;
-      const origAnglesRight = angles.right;
-      angles.left = 0;
-      angles.right -= angleshift;
-      if (angles.right < 0) angles.right += range;
-      let newangle =
-        origAnglesRight == b
-          ? (1 - k) * angles.right + k * angles.left
-          : k * angles.right + (1 - k) * angles.left;
-      newangle += angleshift;
-      if (newangle >= range) newangle -= range;
-      return newangle;
-    };
-
-    // Provided in fix on issue #466 - iOS related
-    this.updateAlphaOffset = function () {
-      scope.initialOffset = false;
-    };
-
-    this.dispose = function () {
-      scope.disconnect();
-    };
-
-    // provided with fix on issue #466
-    this.getAlpha = function () {
-      const { deviceOrientation: device } = scope;
-      return device && device.alpha
-        ? MathUtils.degToRad(device.alpha) + scope.alphaOffset
-        : 0;
-    };
-
-    // provided with fix on issue #466
-    this.getBeta = function () {
-      const { deviceOrientation: device } = scope;
-      return device && device.beta ? MathUtils.degToRad(device.beta) : 0;
-    };
-
-    // Provide gesture before initialising device orientation controls
-    // From PR #659 on the main AR.js repo
-    // Thanks to @ma2yama
-    if(window.DeviceOrientationEvent !== undefined && typeof window.DeviceOrientationEvent.requestPermission === 'function') {
-      this.initPermissionDialog();
-    } else {
-      this.connect();
     }
   }
+  
+  this.getCorrectedHeading = function() {
+    const { deviceOrientation: device } = scope;
+    if (!device) return 0;
+    
+    let heading = 0;
+    
+    if (isIOS) {
+      // iOS always uses webkitCompassHeading
+      heading = 360 - device.webkitCompassHeading;
+      if (scope.orientationOffset) {
+        heading += scope.orientationOffset * (180 / Math.PI);
+        heading = (heading + 360) % 360;
+      }
+    } else {
+      // Android: Check if we have absolute values
+      const isAbsolute = device.absolute === true ||
+        scope.orientationChangeEventName === "deviceorientationabsolute";
+      heading = device.alpha ? device.alpha : 0;
+      if (isAbsolute) {
+        // With absolute values, we can use the alpha value directly as compass heading
+        // but possibly with a system-specific offset
+        // Reverse like iOS if alpha increases clockwise
+        //heading = 360 - heading;
+      }
+      // Reverse direction for Android
+      heading = (360 - heading) % 360;
+      if (heading < 0) heading += 360;
+    }
+    return heading;
+  };
 
+  // NW Added
+  this._orderAngle = function (a, b, range = scope.TWO_PI) {
+    if (
+      (b > a && Math.abs(b - a) < range / 2) ||
+      (a > b && Math.abs(b - a) > range / 2)
+    ) {
+      return { left: a, right: b };
+    } else {
+      return { left: b, right: a };
+    }
+  };
+
+  // NW Added
+  this._getSmoothedAngle = function (a, b, k, range = scope.TWO_PI) {
+    const angles = scope._orderAngle(a, b, range);
+    const angleshift = angles.left;
+    const origAnglesRight = angles.right;
+    angles.left = 0;
+    angles.right -= angleshift;
+    if (angles.right < 0) angles.right += range;
+    let newangle =
+      origAnglesRight == b
+        ? (1 - k) * angles.right + k * angles.left
+        : k * angles.right + (1 - k) * angles.left;
+    newangle += angleshift;
+    if (newangle >= range) newangle -= range;
+    return newangle;
+  };
+
+  // Provided in fix on issue #466 - iOS related
+  this.updateAlphaOffset = function () {
+    scope.initialOffset = false;
+  };
+
+  this.dispose = function () {
+    scope.disconnect();
+  };
+
+  // provided with fix on issue #466
+  this.getAlpha = function () {
+    const { deviceOrientation: device } = scope;
+    return device && device.alpha
+      ? MathUtils.degToRad(device.alpha) + scope.alphaOffset
+      : 0;
+  };
+
+  // provided with fix on issue #466
+  this.getBeta = function () {
+    const { deviceOrientation: device } = scope;
+    return device && device.beta ? MathUtils.degToRad(device.beta) : 0;
+  };
+
+  this.getGamma = function() {
+    const { deviceOrientation: device } = scope;
+    return device && device.gamma ? MathUtils.degToRad(device.gamma) : 0
+  };
+
+  // Option to handle iOS permissions and connecting elsewhere
+  const isiOSWithReq =
+  window.DeviceOrientationEvent !== undefined &&
+  typeof window.DeviceOrientationEvent.requestPermission === "function";
+
+  if (isiOSWithReq && scope.enablePermissionDialog) {
+    scope.initPermissionDialog();
+  }
+  }
+  
   // Provide gesture before initialising device orientation controls
   // From PR #659 on the main AR.js repo
   // Thanks to @ma2yama
@@ -395,4 +447,3 @@ class DeviceOrientationControls extends EventDispatcher {
   }
 }
 export default DeviceOrientationControls;
-


### PR DESCRIPTION
### Description
This PR fixes several iOS-related bugs to provide a more consistent experience across different platforms. It also adds utility functions that may be useful for developers and allows for greater customization.

It includes:

1. **New option for the `DeviceOrientationControls` class: `enablePermissionDialog`**  
   - Type: `boolean`, default: `true`  
   - Determines whether the permission dialog for accessing the device’s motion sensors is shown.  
   - Applies only to iOS devices, where such a prompt is required (see PR #659 in the main AR.js repo).  
   - Setting this to `false` allows developers to handle permission requests themselves, for example, by tying them to a user interaction like their own “Start” button.

2. **Fix: `smoothingFactor` applied on all platforms**  
   - Previously, the `smoothingFactor` was only used on non-iOS devices.  
   - This fix ensures it now applies consistently on all platforms.

3. **Added `getGamma()` function**  
   - Complements the existing `getAlpha()` and `getBeta()` functions.  
   - Useful for applications needing access to gamma (tilt) values.

4. **Added `getCorrectedHeading()` function**  
   - Provides a reliable, cross-platform method for retrieving the user’s current compass heading in degrees (`0° = North`, increasing clockwise).  
   - Uses the stable `webkitCompassHeading` on iOS.  
   - On Android, calculates heading from the `alpha` value of the `DeviceOrientation` event, normalizes it, and applies a correction to align with true geographic north, regardless of device orientation or sensor inconsistencies.

5. **Added screen orientation offset for iOS devices**  
   - Adjusts heading values in landscape mode on iOS by adding an offset of `+90°` or `-90°` in the `onScreenOrientationChangeEvent()` function.  
   - This correction is not required on Android devices.
 

### Testing

The changes were tested on the following devices:

- **T Phone** (Android 14)  
- **iPhone 14 Pro** (iOS 18.5)

Tests were conducted using both the example projects provided in the `examples` folder and a custom project currently in development.

I’d be happy to receive any feedback or suggestions for improvement!
Please test the changes yourself and ask me if you have questions :)

